### PR TITLE
feat: integrate vuepress-plugin-disqus-comment (close #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,48 @@ plugins: {
 },
 ```
 
-There is only one option available: `name` which specifies the name of the disqus component. Defaults to: `Disqus`.
+Please check out [Config](#config) for options.
 
 Note that Vuepress allows multiple syntaxes to register plugins. See [Vuepress documentation on how to use a plugin](https://vuepress.vuejs.org/plugin/using-a-plugin.html) for more information.
 
 ## Use the Disqus component
 
-```html
-<ClientOnly>
-    <Disqus shortname="my-website-shortname" />
-</ClientOnly>
-```
+This plugin present a out-of-box SSR-friendly component  - `<Disqus/>`. Just put it wherever you like, and Disqus will be embedded in the right place. For example:
 
-It is important to wrap the `Disqus` component between the `ClientOnly` component (natively provided by vuepress) otherwise `npm run build` will fail. This is because the `Disqus` component cannot be precompiled by the server and should only live on the client side.
+```html
+<template>
+  <div>
+    <Content />
+    <!-- ...... -->
+    <Disqus />
+  </div>
+</template>
+```
+Or you can simply put it in your `.md` file.
+```markdown
+## Hello VuePress
+
+This is a demo.
+
+<Disqus/>
+```
 
 You can use all the props and events defined by [vue-disqus](https://github.com/ktquez/vue-disqus).
 
 Prop            | Data Type  | required  | Description
 --------------- | ---------- | --------- | -----------
 `shortname`     | String     | true      | Your disqus shortname.
+`url`           | String     | false     | Your URL where Disqus is present
 `title`         | String     | false     | Title that identifies the current page.
 `identifier`    | String     | false     | The page's unique identifier
 `sso_config`    | Object     | false     | Single sign-on (SSO)
 `api_key`       | String     | false     | Your API key disqus
 `remote_auth_s3`| String     | false     | implementation with Laravel/PHP
 `language`      | String     | false     | Language overrides
+
+## Config 
+
+See the table above. All the props are also configuration options for this plugin. They'll be passed to every `Disqus` component. You're still able to override it by passing down props. Note that if you don't set language, it'll use VuePress's $lang as default language.
+
+There's still one option available - `name` which specifies the name of the disqus component. Defaults to: `Disqus`.
+

--- a/enhanceAppFile.js
+++ b/enhanceAppFile.js
@@ -1,0 +1,35 @@
+export default ({ Vue }) => {
+  const options = JSON.parse(DISQUS_OPTIONS);
+
+  const name = options.name || "Disqus"
+  const component = () => import('vue-disqus/src/vue-disqus.vue')
+
+  // options will be pass down as props to the components later
+  delete options.name
+
+  Vue.component(name, {
+    functional: true,
+    render(h, { parent, props }) {
+      // Get default lang
+      let DefaultLanguage;
+      // The default value is en-US, but it's not a option for Disqus localization
+      if (parent.$lang === "en-US") {
+        DefaultLanguage = "en";
+      } else {
+        DefaultLanguage = parent.$lang.replace(/\-/, "_");
+      }
+
+      // SSR-friendly
+      if (parent._isMounted) {
+        return h(component, {
+          // Priority: VuePress's $lang as default language < global configuration < props
+          props: Object.assign({ language: DefaultLanguage }, options, props)
+        });
+      } else {
+        parent.$once("hook:mounted", () => {
+          parent.$forceUpdate();
+        });
+      }
+    }
+  });
+};

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-module.exports = (options) => ({
-    enhanceAppFiles () {
-        let name = options.name || 'Disqus'
-        let component = `() => import('vue-disqus/src/vue-disqus.vue')`
+const path = require('path')
 
-        return {
-            name: 'disqus-component-registration',
-            content: `export default ({ Vue }) => { Vue.component('${name}', ${component}) }`
-        }
-    }
+module.exports = (options) => ({
+  name: "disqus",
+
+  enhanceAppFiles: [path.resolve(__dirname, "enhanceAppFile.js")],
+
+  define: {
+    DISQUS_OPTIONS: JSON.stringify(options)
+  }
 })


### PR DESCRIPTION
Sorry for late PR. 

As I mentioned in #4 , I implement extra features:
- config globally
- build-in SSR friendly component
- use vuepress's `$lang` as default language


And there's no breaking change since I keep the `name` options.